### PR TITLE
Updated for iOS 7+

### DIFF
--- a/WTStatusBar/WTStatusView.m
+++ b/WTStatusBar/WTStatusView.m
@@ -90,6 +90,9 @@
 - (void)setStatusBarColor:(UIColor *)color
 {
     CGFloat windowAlpha = ([[UIApplication sharedApplication] statusBarStyle] == UIStatusBarStyleBlackTranslucent) ? 0.5 : 1.0;
+    if (floor(NSFoundationVersionNumber) >= NSFoundationVersionNumber_iOS_7_0) {
+        windowAlpha = 1;
+    }
     self.backgroundColor = [color colorWithAlphaComponent:windowAlpha];
 }
 


### PR DESCRIPTION
As there's no translucent status bar bar, always make the status bar black on iOS 7 and above.  Otherwise without this fix, and if the user has a status bar which is UIStatusBarStyleLightContent, looks like the screen shot attached

![ios simulator screen shot 6 aug 2015 4 16 01 pm](https://cloud.githubusercontent.com/assets/1784679/9105029/89bec4b0-3c56-11e5-89fa-00135dd55f92.png)
